### PR TITLE
Update dependency versions

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,10 +4,10 @@ version: 0.1.0
 dependencies:
   kemal:
     github: sdogruyol/kemal
-    version: 0.6.0
+    version: => 0.6.0
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 1.2.1
+    version: ~> 1.2
 
 
 authors:


### PR DESCRIPTION
This locked any dependant app to kemal 0.6.0, instead of using that as a
baseline for anything newer.

crystal-redis is up to 1.6.2, removing the final digit of the version
constraint should allow for anything up to 2.x (which would indicate a
breaking change).
